### PR TITLE
Don't store IDE profiles in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 **/*.rs.bk
+.vscode
 /todo.*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "typeinfo": "c"
-    }
-}


### PR DESCRIPTION
It would be possible to store a .editorconfig instead.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>