### PR TITLE
Run dockerized tests in release mode

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -42,7 +42,7 @@ RUN cargo install cargo-deb
 COPY . /app
 WORKDIR /app/linux
 
-RUN cargo test
+RUN cargo test --release
 
 RUN mkdir -p dist/
 

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -32,7 +32,7 @@ RUN set -eux; \
 COPY . /app
 WORKDIR /app/linux
 
-RUN cargo test
+RUN cargo test --release
 
 RUN make rpm
 


### PR DESCRIPTION
Avoids the need to build in both debug an release modes