### PR TITLE
Expose MiscDriver

### DIFF
--- a/linux/uhid-tokio/src/lib.rs
+++ b/linux/uhid-tokio/src/lib.rs
@@ -104,6 +104,7 @@ extern crate uhid_sys;
 pub use codec::{Bus, InputEvent, OutputEvent, StreamError};
 pub use uhid_device::CreateParams;
 pub use uhid_device::UHIDDevice;
+pub use misc_driver::MiscDriver;
 
 mod character_device;
 mod codec;


### PR DESCRIPTION
Without MiscDriver exposed, UHIDDevice cannot be easily contained in structs. It has a generic parameter and referring to it with a `T` causes the compiler to complain. Exposing it allows you to do something like:
```rust

pub struct HIDController {
    pub device: UHIDDevice<MiscDriver>
}

```