### PR TITLE
Fix/selinux on debian

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -15,7 +15,9 @@ install: build
 	sudo install -m 644 ${systemdaemondir}/softu2f.service /etc/systemd/system/softu2f.service
 	sudo install -m 644 ${systemdaemondir}/softu2f.socket /etc/systemd/system/softu2f.socket
 	sudo install -m 644 ${systemdaemondir}/softu2f-tmpfiles.conf /etc/tmpfiles.d/softu2f.conf
-	sudo ${selinuxpolicydir}/softu2f-system-daemon.sh
+	if [ -n "$$(which sestatus)" ]; then \
+		sudo ${selinuxpolicydir}/softu2f-system-daemon.sh; \
+	fi
 	sudo systemctl --system enable softu2f.socket
 	sudo systemctl --system start softu2f.socket
 	sudo install -m 755 target/debug/softu2f-user-daemon /usr/libexec/softu2f/user-daemon

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -15,7 +15,7 @@ install: build
 	sudo install -m 644 ${systemdaemondir}/softu2f.service /etc/systemd/system/softu2f.service
 	sudo install -m 644 ${systemdaemondir}/softu2f.socket /etc/systemd/system/softu2f.socket
 	sudo install -m 644 ${systemdaemondir}/softu2f-tmpfiles.conf /etc/tmpfiles.d/softu2f.conf
-	if [ -n "$$(which sestatus)" ]; then \
+	if [ -n "$$(which sestatus 1>/dev/null 2>&1)" ]; then \
 		sudo ${selinuxpolicydir}/softu2f-system-daemon.sh; \
 	fi
 	sudo systemctl --system enable softu2f.socket


### PR DESCRIPTION
I noticed that `make install` fails on debian based systems since selinux is missing. I've added a check for that step. 