### PR TITLE
Remove schema search attribute and improved bogus appid handling

### DIFF
--- a/linux/user-daemon/src/stores/secret_service_store.rs
+++ b/linux/user-daemon/src/stores/secret_service_store.rs
@@ -188,12 +188,12 @@ fn search_attributes(app_id: &AppId, handle: &KeyHandle) -> Vec<(&'static str, S
         ("application", "com.github.danstiner.rust-u2f".to_string()),
         ("u2f_app_id_hash", app_id.to_base64()),
         ("u2f_key_handle", handle.to_base64()),
-        ("xdg:schema", "com.github.danstiner.rust-u2f".to_string()),
     ]
 }
 
 fn registration_attributes(app_id: &AppId, handle: &KeyHandle) -> Vec<(&'static str, String)> {
     let mut attributes = search_attributes(app_id, handle);
+    attributes.push(("xdg:schema", "com.github.danstiner.rust-u2f".to_string()));
     attributes.push(("times_used", 0.to_string()));
 
     let start = SystemTime::now();

--- a/u2f-core/src/app_id.rs
+++ b/u2f-core/src/app_id.rs
@@ -11,6 +11,7 @@ pub struct AppId(pub(crate) [u8; 32]);
 
 impl AppId {
     pub fn from_bytes(slice: &[u8]) -> AppId {
+        assert_eq!(slice.len(), 32);
         let mut bytes = [0u8; 32];
         bytes.copy_from_slice(slice);
         AppId(bytes)

--- a/u2f-core/src/known_app_ids.rs
+++ b/u2f-core/src/known_app_ids.rs
@@ -1,15 +1,26 @@
 use std::collections::HashMap;
+use std::collections::HashSet;
 
 use crate::app_id::AppId;
 use ring::digest;
 
-// Known bogus app id hash, Chrome does a bogus register command after certain authentication failures,
-// this "force[s] the user to tap the [key] before revealing [the authentication state to the site]"
+// Known bogus app id hashes, Browsers do a bogus register command after certain authentication failures,
+// this "force[s] the user to tap the [key] before revealing [the authentication state to the site]".
+//
+// In the future we should perhaps display a notification to the user about the authentication failure.
 //
 // See https://github.com/google/u2f-ref-code/blob/b11e47c5bca093c93d802286bead3db78a4b0b9f/u2f-chrome-extension/usbsignhandler.js#L118
-pub const BOGUS_APP_ID_HASH: AppId = AppId([
+
+// Chrome uses app id QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE=
+pub const BOGUS_APP_ID_HASH_CHROME: AppId = AppId([
     65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8,
     65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8, 65u8,
+]);
+
+// Firefox uses app id AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+pub const BOGUS_APP_ID_HASH_FIREFOX: AppId = AppId([
+    0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+    0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
 ]);
 
 pub fn try_reverse_app_id(app_id: &AppId) -> Option<String> {

--- a/u2f-core/src/response.rs
+++ b/u2f-core/src/response.rs
@@ -29,6 +29,7 @@ pub enum Response {
     TestOfUserPresenceNotSatisfied,
     InvalidKeyHandle,
     UnknownError,
+    Bogus,
 }
 
 impl Response {
@@ -107,6 +108,10 @@ impl Response {
             Response::UnknownError => {
                 // Status word [2 bytes]
                 StatusCode::UnknownError.write(&mut bytes);
+            }
+            Response::Bogus => {
+                // Status word [2 bytes]
+                StatusCode::NoError.write(&mut bytes);
             }
         }
         bytes


### PR DESCRIPTION
- Some very old secret entries were missing the xdg:schema attribute on my computer, that may not have been an issue in released builds but there is no reason to filter on that attribute so I'm removing it
- Cleans up bogus app id handling to work better in Firefox