### PR TITLE
Add ssh to known app id's

### DIFF
--- a/linux/user-daemon/src/user_presence.rs
+++ b/linux/user-daemon/src/user_presence.rs
@@ -105,7 +105,7 @@ impl UserPresence for NotificationUserPresence {
         application: &AppId,
     ) -> Box<dyn Future<Item = bool, Error = io::Error>> {
         let site_name = try_reverse_app_id(application).unwrap_or(String::from("site"));
-        let message = format!("Register with {}", site_name);
+        let message = format!("Register {}", site_name);
         self.test_user_presence(&message)
     }
 
@@ -114,7 +114,7 @@ impl UserPresence for NotificationUserPresence {
         application: &AppId,
     ) -> Box<dyn Future<Item = bool, Error = io::Error>> {
         let site_name = try_reverse_app_id(application).unwrap_or(String::from("site"));
-        let message = format!("Authenticate with {}", site_name);
+        let message = format!("Authenticate {}", site_name);
         self.test_user_presence(&message)
     }
 

--- a/u2f-core/src/known_app_ids.rs
+++ b/u2f-core/src/known_app_ids.rs
@@ -54,6 +54,7 @@ lazy_static! {
         map.insert(from_url("https://www.fastmail.com"), "www.fastmail.com");
         map.insert(from_url("webauthn.bin.coffee"), "webauthn.bin.coffee");
         map.insert(from_url("webauthn.io"), "webauthn.io");
+        map.insert(from_url("ssh:"), "ssh key");
 
         map
     };


### PR DESCRIPTION
Ssh keys tied to a U2F authenticator can be created, e.g. `ssh-keygen -t ecdsa-sk`

This is neat so I'm adding it as a known app id, but I will note this tool doesn't really provide meaningful security when used with ssh keys in this way, I would highly suggest using a hardware authenticator instead, or just directly storing the ssh key in your gnome keychain without going through the extra complexity tying your keys to this tool.