### PR TITLE
Use bitflags!'s from_bits() instead of unsafe memory casting.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ members = [
 [profile.release]
 lto = true
 panic = 'abort'
+debug-assertions = true

--- a/linux/uhid-tokio/src/codec.rs
+++ b/linux/uhid-tokio/src/codec.rs
@@ -227,9 +227,8 @@ fn decode_event(event: sys::uhid_event) -> Result<OutputEvent, StreamError> {
     if let Some(event_type) = to_uhid_event_type(event.type_) {
         match event_type {
             sys::uhid_event_type_UHID_START => Ok(unsafe {
-                let payload = &event.u.start;
                 OutputEvent::Start {
-                    dev_flags: mem::transmute(payload.dev_flags),
+                    dev_flags: DevFlags::from_bits_truncate(event.u.start.dev_flags)
                 }
             }),
             sys::uhid_event_type_UHID_STOP => Ok(OutputEvent::Stop),


### PR DESCRIPTION
Fixes https://github.com/danstiner/rust-u2f/issues/98